### PR TITLE
use node_modules for webapp

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,4 @@
 !packages/webapp
 packages/server/node_modules
 packages/webapp/node_modules
+packages/webapp/build

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,3 +3,4 @@ plugins:
     spec: "@yarnpkg/plugin-workspace-tools"
 
 yarnPath: .yarn/releases/yarn-berry.js
+nodeLinker: node-modules

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,7 +1,7 @@
 FROM node:14-buster-slim AS build
 WORKDIR /home/node/app
 COPY [".", "."]
-RUN echo '\nnodeLinker: node-modules' >> .yarnrc.yml && yarn set version berry && cd packages/server && yarn workspaces focus --production
+RUN yarn set version berry && cd packages/server && yarn workspaces focus --production
 
 FROM gcr.io/distroless/nodejs-debian10:14 AS run
 COPY --from=build /home/node/app/packages/server /home/node/app

--- a/webapp.Dockerfile
+++ b/webapp.Dockerfile
@@ -1,7 +1,7 @@
 FROM node:14-buster-slim AS build
 COPY [".", "/usr/src/app"]
 WORKDIR /usr/src/app/packages/webapp
-RUN yarn set version berry && yarn workspaces focus
+RUN yarn set version berry && yarn workspaces focus && yarn run build
 
 FROM abdennour/nginx-distroless-unprivileged AS run
 COPY --chown=1001:0 packages/webapp/nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
use node_modules for webapp also as snowpack does not work with yarn pnp
also ensures the webapp is actually built and not copied from local, whoops